### PR TITLE
get_channel_id inputparameter must be an integer

### DIFF
--- a/desugreet/__main__.py
+++ b/desugreet/__main__.py
@@ -14,7 +14,7 @@ def main():
         bot.token = data["token"]
         bot.role = data["role"]
         bot.welcome_msg = data["message"]
-        bot.log_channel_id = data["log"]
+        bot.log_channel_id = int(data["log"])
         bot.run()
     else:
         print("Please create the config file .desugreet in the directory you are running the bot from!")


### PR DESCRIPTION
Client.get_channel(id) method requires an integer variable however a string was given.
Converting the variable to integer when reading the config.