### PR TITLE
mention instead of printing the user name

### DIFF
--- a/desugreet/bot.py
+++ b/desugreet/bot.py
@@ -19,12 +19,12 @@ async def on_member_join(member):
     else:
         print("check your config file, the role does not exist!")
     await member.send(welcome_msg.format(member, server))
-    await client.get_channel(log_channel_id).send("{0.name} has joined".format(member))
+    await client.get_channel(log_channel_id).send("{0.mention} has joined".format(member))
 
 
 @client.event
 async def on_member_remove(member):
-    await client.get_channel(log_channel_id).send("{0.name} has left".format(member))
+    await client.get_channel(log_channel_id).send("{0.mention} has left".format(member))
 
 
 @client.event


### PR DESCRIPTION
Since the log channel is open to all members now, users can be mentioned.
With the mention, it will be easier to check new users.