### PR TITLE
Force discord.py version to 1.5 or above

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
 
     packages=find_packages(),
 
-    install_requires=['discord.py', 'dateutils'],
+    install_requires=['discord.py>=1.5', 'dateutils'],
     entry_points={
       'console_scripts': [
           'desugreet = desugreet.__main__:main'


### PR DESCRIPTION
The new gateway intent feature requires discord.py version 1.5 or above