### PR TITLE
Feat captcha update

### DIFF
--- a/desugreet/__main__.py
+++ b/desugreet/__main__.py
@@ -12,9 +12,12 @@ def main():
             data = json.load(data_file)
 
         bot.token = data["token"]
-        bot.role = data["role"]
-        bot.welcome_msg = data["message"]
-        bot.log_channel_id = int(data["log"])
+        bot.member_role_str = data["member-role"]
+        bot.welcome_msg = data["welcome-message"]
+        bot.log_channel_id = int(data["log-channel-id"])
+        bot.entrance_role_str = data["entrance-role"]
+        bot.entrance_channel_id = int(data["entrance-channel-id"])
+        bot.entrance_msg = data["entrance-message"]
         bot.run()
     else:
         print("Please create the config file .desugreet in the directory you are running the bot from!")

--- a/desugreet/bot.py
+++ b/desugreet/bot.py
@@ -27,9 +27,9 @@ async def on_member_join(member):
     try:
         await member.send(welcome_msg.format(member, server))
     except discord.errors.Forbidden:
-        await client.get_channel(log_channel_id).send("{0.mention} (closed DM) has joined".format(member))
+        await client.get_channel(log_channel_id).send("{0.mention} (closed DM) isch cho".format(member))
     else:
-        await client.get_channel(log_channel_id).send("{0.mention} has joined".format(member))
+        await client.get_channel(log_channel_id).send("{0.mention} isch cho".format(member))
 
 @client.event
 async def on_member_update(member_before, member_after):
@@ -49,7 +49,7 @@ async def on_member_update(member_before, member_after):
 
 @client.event
 async def on_member_remove(member):
-    await client.get_channel(log_channel_id).send("{0.name}#{0.discriminator} has left".format(member))
+    await client.get_channel(log_channel_id).send("{0.name}#{0.discriminator} isch gange".format(member))
 
 
 @client.event

--- a/desugreet/bot.py
+++ b/desugreet/bot.py
@@ -102,9 +102,11 @@ async def on_message(message):
         text = text.format(diff)
         await message.channel.send(text)
     elif message.content.startswith('!clear-entrance'):
-        # TODO: only mods shall be able to run this command
-        async for message in entrance_channel.history(limit=None):
-            await message.delete()
+        if message.author.guild_permissions.manage_messages:
+            async for message in entrance_channel.history(limit=None):
+                await message.delete()
+        else:
+            await message.reply("{0.mention} du häsch ke Berechtigung für de Command".format(message.author))
 
 
 @client.event

--- a/desugreet/bot.py
+++ b/desugreet/bot.py
@@ -86,6 +86,8 @@ async def on_member_remove(member):
 
 @client.event
 async def on_message(message):
+    global entrance_track_buffer
+
     if message.author == client.user:
         return
 
@@ -103,8 +105,11 @@ async def on_message(message):
         await message.channel.send(text)
     elif message.content.startswith('!clear-entrance'):
         if message.author.guild_permissions.manage_messages:
+            # remove all messages in entrance channel
             async for message in entrance_channel.history(limit=None):
                 await message.delete()
+            # clear out entrance message buffer
+            entrance_track_buffer = {}
         else:
             await message.reply("{0.mention} du häsch ke Berechtigung für de Command".format(message.author))
 

--- a/desugreet/bot.py
+++ b/desugreet/bot.py
@@ -30,7 +30,6 @@ async def on_member_join(member):
     entrance_track_buffer[member] = []  # create list buffer with a member obj key
     entrance_track_buffer[member].append(await client.get_channel(entrance_channel_id).send(entrance_msg.format(member)))
 
-None
 @client.event
 async def on_member_update(member_before, member_after):
     server = member_after.guild

--- a/desugreet/bot.py
+++ b/desugreet/bot.py
@@ -57,6 +57,7 @@ async def on_member_update(member_before, member_after):
         if member_after in entrance_track_buffer.keys():
             for msg in entrance_track_buffer[member_after]:
                 await msg.delete()
+            del entrance_track_buffer[member_after]
 
     ## check for boost/de-boosting transition
     boost_role = discord.utils.get(server.roles, name='Nitro Booster')

--- a/desugreet/bot.py
+++ b/desugreet/bot.py
@@ -31,6 +31,21 @@ async def on_member_join(member):
     else:
         await client.get_channel(log_channel_id).send("{0.mention} has joined".format(member))
 
+@client.event
+async def on_member_update(member_before, member_after):
+    server = member_after.guild
+
+    # check for boost/de-boosting
+    boost_role = discord.utils.get(server.roles, name='Nitro Booster Test')
+    member_before_boost = boost_role in member_before.roles
+    member_after_boost = boost_role in member_after.roles
+
+    if member_after_boost and not member_before_boost:
+        reaction_emoji = discord.utils.get(server.emojis, name='cirnoSmile')
+        await client.get_channel(log_channel_id).send("{0.mention} het de Server boosted. Danke! {1}".format(member_after, reaction_emoji))
+    if member_before_boost and not member_after_boost:
+        reaction_emoji = discord.utils.get(server.emojis, name='saddest')
+        await client.get_channel(log_channel_id).send("{0.mention} het ufghört de Server zbooste. {1}".format(member_after, reaction_emoji))
 
 @client.event
 async def on_member_remove(member):

--- a/desugreet/bot.py
+++ b/desugreet/bot.py
@@ -28,7 +28,7 @@ async def on_member_join(member):
 
 @client.event
 async def on_member_remove(member):
-    await client.get_channel(log_channel_id).send("{0.name} has left".format(member))
+    await client.get_channel(log_channel_id).send("{0.name}#{0.discriminator} has left".format(member))
 
 
 @client.event

--- a/desugreet/bot.py
+++ b/desugreet/bot.py
@@ -22,8 +22,14 @@ async def on_member_join(member):
         await member.add_roles(member_role)
     else:
         print("check your config file, the role does not exist!")
-    await member.send(welcome_msg.format(member, server))
-    await client.get_channel(log_channel_id).send("{0.mention} has joined".format(member))
+    
+    # detect when member does not accept DM
+    try:
+        await member.send(welcome_msg.format(member, server))
+    except discord.errors.Forbidden:
+        await client.get_channel(log_channel_id).send("{0.mention} (closed DM) has joined".format(member))
+    else:
+        await client.get_channel(log_channel_id).send("{0.mention} has joined".format(member))
 
 
 @client.event

--- a/desugreet/bot.py
+++ b/desugreet/bot.py
@@ -88,6 +88,10 @@ async def on_message(message):
         text += '\nsource: https://github.com/swissdesu/DesuGreet'
         text = text.format(diff)
         await message.channel.send(text)
+    elif message.content.startswith('!clear-entrance'):
+        entrance_channel = client.get_channel(entrance_channel_id)
+        async for message in entrance_channel.history(limit=None):
+            await message.delete()
 
 
 @client.event

--- a/desugreet/bot.py
+++ b/desugreet/bot.py
@@ -4,6 +4,7 @@ from dateutil.relativedelta import relativedelta
 
 intents = discord.Intents.default()
 intents.members = True
+intents.message_content = True
 
 client = discord.Client(intents=intents)
 token = None

--- a/desugreet/bot.py
+++ b/desugreet/bot.py
@@ -36,7 +36,7 @@ async def on_member_update(member_before, member_after):
     server = member_after.guild
 
     # check for boost/de-boosting
-    boost_role = discord.utils.get(server.roles, name='Nitro Booster Test')
+    boost_role = discord.utils.get(server.roles, name='Nitro Booster')
     member_before_boost = boost_role in member_before.roles
     member_after_boost = boost_role in member_after.roles
 


### PR DESCRIPTION
# Main Changes

- This update places new users to a quarantine channel first, by giving the "entrance-role".
- A moderator shall review the user and either remove the "entrance-role" or ban the user.
- When the "entrance-role" is removed, the bot automatically adds member-role to the new member.
- Users with 'manage_messages' permissions can run `!clear-entrance` command to remove all messages in "entrance-channel".
- The bot tracks his entrance message and messages from the new users by himself to remove them after that user was permitted for member-role.

## New .json config file
The new version of the bot requires an updated `.desugreet` .json config file in the following format:

```json
{
"token": "your top secret token",
"member-role": "Member-Desu",
"entrance-role": "entrance-person",
"entrance-channel-id": "channel ID of the entrance channel",
"entrance-message": "Säli {0.mention}.\nSchriib hie schnell irgend e Scheiss uf Schwitzerdütsch ine zum bewiise, dass du ke Maschine bisch.\nE Mod wird dir denn e Member-Rolle geh.",
"welcome-message": "Hallo {0.mention}, willkommen bei {1.name} \n \n Bevor du dich ins Getümmel wirfst, bitte
lies dir kurz die Regeln für unseren Server durch. \n \n Alles verstanden? Dann viel Spass auf unserem Server! \n",
"log-channel-id": "channel ID of the log channel"
}

```


# Additional Changes
This update also brings the following changes
- Added `message_content` intent as bots need them to read messages from channels.
- When logging leaving users, also print out their #descriminator to facilitate searching for the user in discords user-clitent search bar.
- handle exception when a new member blocks messages per DM. Print out (closed DM) in the log.
- Also log when a member boost or de-boost the server.
- Mainly use swiss german for log text.